### PR TITLE
DRAM Vendor ID change

### DIFF
--- a/jedec_id.h
+++ b/jedec_id.h
@@ -54,7 +54,7 @@ struct spd_jedec_manufacturer jep106[] = {
 		{ 0, 0x2a, "Ricoh"},
 		{ 0, 0xab, "VLSI"},
 		{ 0, 0x2c, "Micron Technology"},
-		{ 0, 0xad, "Hynix Semiconductor"},
+		{ 0, 0xad, "SKHynix Semiconductor"},
 		{ 0, 0xae, "OKI Semiconductor"},
 		{ 0, 0x2f, "ACTEL"},
 		{ 0, 0xb0, "Sharp"},


### PR DESCRIPTION
Signed-off-by: HJ <phj4403@naver.com>

jedec_id.h 
```
--- a/jedec_id.h
+++ b/jedec_id.h
@@ -54,7 +54,7 @@ struct spd_jedec_manufacturer jep106[] = {
                { 0, 0x2a, "Ricoh"},
                { 0, 0xab, "VLSI"},
                { 0, 0x2c, "Micron Technology"},
-               { 0, 0xad, "Hynix Semiconductor"},
+               { 0, 0xad, "SKHynix Semiconductor"},^M
                { 0, 0xae, "OKI Semiconductor"},
                { 0, 0x2f, "ACTEL"},
                { 0, 0xb0, "Sharp"},
```
